### PR TITLE
src: fix import of amplify

### DIFF
--- a/react/src/App.js
+++ b/react/src/App.js
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 
-import Amplify from "aws-amplify";
+import { Amplify } from "aws-amplify";
 import { Authenticator } from "@aws-amplify/ui-react";
 import "@aws-amplify/ui-react/styles.css";
 


### PR DESCRIPTION
Issue:
```
ERROR in ./src/App.js 16:0-17
export 'default' (imported as 'Amplify') was not found in 'aws-amplify' (possible exports: API, APIClass, AWSCloudWatchProvider, AWSKinesisFirehoseProvider, AWSKinesisProvider, AWSPinpointProvider, AmazonPersonalizeProvider, Amplify, Analytics, Auth, AuthModeStrategyType, Cache, ClientDevice, DataStore, Geo, Hub, I18n, Interactions, Logger, Notifications, Predicates, Predictions, PubSub, ServiceWorker, Signer, SortDirection, Storage, StorageClass, graphqlOperation, syncExpression, withSSRContext)
```

fix:
```JS
import { Amplify } from "aws-amplify";
```